### PR TITLE
Added method to add qemu to the path

### DIFF
--- a/docs/howto-setup-test-env.md
+++ b/docs/howto-setup-test-env.md
@@ -66,6 +66,19 @@ If you met any problems, please contact us.
 We have provided pre-built qemu binaries under `bin/qemu/install`. If you met 
 any problems, please contact us.
 
+If you met any error like the following:
+
+```
+========== Start Running ......
+./.run.exec: line 16: qemu-riscv64: command not found
+```
+
+Remember to add prebuilt qemu to your path. You could add the following line to the end of your path file. Source to update your current shell environment.
+
+```
+export PATH=$PATH:your-path-to/aosp/test/riscv/bin/qemu/install/bin
+```
+
 # 4. kernel
 
 We have provided pre-built kernel image under `bin/kernel`. If you met any 


### PR DESCRIPTION
When I was trying to set up the environment and run the tests, I got this message from run.sh.
`./.run.exec: line 16: qemu-riscv64: command not found`
I found it caused by I don't have qemu-riscv64 in my path, so I share my experience and give out my solution in qemu section.